### PR TITLE
Moves autorelease pool inside the loop

### DIFF
--- a/EarlGrey/Core/GREYElementFinder.m
+++ b/EarlGrey/Core/GREYElementFinder.m
@@ -37,8 +37,8 @@
   NSParameterAssert(elementProvider);
   I_CHECK_MAIN_THREAD();
   NSMutableArray *matchingElements = [[NSMutableArray alloc] init];
-  @autoreleasepool {
-    for (id element in [elementProvider dataEnumerator]) {
+  for (id element in [elementProvider dataEnumerator]) {
+    @autoreleasepool {
       if ([_matcher matches:element]) {
         [matchingElements addObject:element];
       }


### PR DESCRIPTION
Moves autorelease pool to the intended position.

The autorelease pool clearly was intended to be used inside the loop. Fixing this typo. We found this bug as part of investigation of https://bugs.chromium.org/p/chromium/issues/detail?id=675399#c9